### PR TITLE
Create separate cron workflow

### DIFF
--- a/.github/workflows/invite.yml
+++ b/.github/workflows/invite.yml
@@ -1,7 +1,6 @@
 name: invite
 on:
-  schedule:
-    - cron:  '14 14 * * *' # Runs at 14:14 UTC every day
+  workflow_call:
   repository_dispatch:
     types: [invite]
   workflow_dispatch:

--- a/.github/workflows/invite_cron.yml
+++ b/.github/workflows/invite_cron.yml
@@ -1,0 +1,7 @@
+name: invite (cron)
+on:
+  schedule:
+    - cron:  '14 14 * * *' # Runs at 14:14 UTC every day
+jobs:
+  invite:
+    uses: ./.github/workflows/invite.yml


### PR DESCRIPTION
GitHub will suspend the scheduled trigger for GitHub action workflows if
there is no commit in the repository for the past 60 days.

We still want to run the invite workflow with repository_dispatch event,
so this commit create a different cron workflow to mitigate the issue.